### PR TITLE
Publish `zachsbot` library to crates.io

### DIFF
--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zachsbot"
 description = "A library of re-usable functions for my bots"
-version = "0.0.0"
+version = "0.0.0-a"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sneakycrow/zachsbot"

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -1,7 +1,9 @@
 [package]
 name = "zachsbot"
+description = "A library of re-usable functions for my bots"
 version = "0.0.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lib/core/Cargo.toml
+++ b/lib/core/Cargo.toml
@@ -4,6 +4,7 @@ description = "A library of re-usable functions for my bots"
 version = "0.0.0"
 edition = "2021"
 license = "MIT"
+repository = "https://github.com/sneakycrow/zachsbot"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Published [here](https://crates.io/crates/zachsbot)